### PR TITLE
Add custom API to load orders

### DIFF
--- a/webapp/src/components/ExchangePage/index.jsx
+++ b/webapp/src/components/ExchangePage/index.jsx
@@ -444,9 +444,10 @@ async function fetchUserOrdersApi(account, uniswapEXContract, setInputError) {
         order.minReturn = ethers.utils.bigNumberify(order.minReturn.toString())
 
         const amount = await amountOfOrder(order, uniswapEXContract)
-        if (!amount.isZero() && ordersAdded[order.tx] === undefined) {
+        const key = keyOfOrder(order)
+        if (!amount.isZero() && ordersAdded[key] === undefined) {
           orders.push({ ...order, amount })
-          ordersAdded[order.tx] = orders.length - 1
+          ordersAdded[key] = orders.length - 1
         }
       }
     } catch (e) {


### PR DESCRIPTION
Adds a custom UniswapEX API to load the orders of the user, the new API is used alongside with the old Etherscan method, in parallel